### PR TITLE
Add ping check and latency display

### DIFF
--- a/DOCKER_README.md
+++ b/DOCKER_README.md
@@ -4,7 +4,7 @@
 ![Docker Image Size](https://img.shields.io/docker/image-size/syntaxsorcerer7/internet-monitor)
 ![Docker Stars](https://img.shields.io/docker/stars/syntaxsorcerer7/internet-monitor)
 
-A containerized internet monitoring tool that continuously tracks your internet connection availability and visualizes it in a clear web interface with professional charts.
+A containerized internet monitoring tool that continuously tracks your internet connection availability and ping latency and visualizes it in a clear web interface with professional charts.
 
 ## 🚀 Quick Start
 
@@ -22,8 +22,8 @@ open http://localhost:8000
 ## 📊 Features
 
 ### 📈 Three Monitoring Levels
-- **📍 Detailed History**: Minute-by-minute recording of all connectivity tests
-- **⏰ 24-Hour Overview**: Hourly aggregation with availability percentages  
+- **📍 Detailed History**: Minute-by-minute recording of all connectivity tests including ping latency
+- **⏰ 24-Hour Overview**: Hourly aggregation with availability percentages
 - **📅 30-Day Overview**: Daily long-term trends for SLA monitoring
 
 ### 🎯 Professional Availability Levels
@@ -38,6 +38,7 @@ open http://localhost:8000
 - **Persistent Storage**: SQLite database with automatic cleanup
 - **Multi-Platform**: Supports AMD64 and ARM64 (Raspberry Pi, Apple Silicon)
 - **High Performance**: Minimal resource usage through Alpine Linux
+- **Ping Latency Measurement**: ICMP ping to capture latency and display in dashboard
 
 ## ⚙️ Configuration
 

--- a/DOCKER_README.md
+++ b/DOCKER_README.md
@@ -23,8 +23,8 @@ open http://localhost:8000
 
 ### 📈 Three Monitoring Levels
 - **📍 Detailed History**: Minute-by-minute recording of all connectivity tests including ping latency
-- **⏰ 24-Hour Overview**: Hourly aggregation with availability percentages
-- **📅 30-Day Overview**: Daily long-term trends for SLA monitoring
+- **⏰ 24-Hour Overview**: Hourly aggregation with availability percentages plus average and 99th percentile ping
+- **📅 30-Day Overview**: Daily long-term trends including average and 99th percentile ping for SLA monitoring
 
 ### 🎯 Professional Availability Levels
 - 🟢 **Excellent** (≥99.9%): Enterprise-grade availability

--- a/DOCKER_README.md
+++ b/DOCKER_README.md
@@ -35,6 +35,7 @@ open http://localhost:8000
 ### ⚡ Technical Highlights
 - **Real-time Updates**: Automatic chart refresh every 60 seconds
 - **Responsive Design**: Optimized for desktop, tablet, and mobile
+- **Toggleable Charts**: Switch between availability and ping views
 - **Persistent Storage**: SQLite database with automatic cleanup
 - **Multi-Platform**: Supports AMD64 and ARM64 (Raspberry Pi, Apple Silicon)
 - **High Performance**: Minimal resource usage through Alpine Linux

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ cd internet-check
 ### 📈 Drei Monitoring-Ebenen
 
 - **📍 Detaillierter Verlauf**: Minutengenaue Aufzeichnung aller Connectivity-Tests inklusive Ping-Latenz
-- **⏰ 24-Stunden-Übersicht**: Stündliche Aggregation mit Verfügbarkeitsprozenten
-- **📅 30-Tage-Übersicht**: Tägliche Langzeittrends für SLA-Monitoring
+- **⏰ 24-Stunden-Übersicht**: Stündliche Aggregation mit Verfügbarkeitsprozenten sowie durchschnittlicher und 99%-Perzentil-Ping
+- **📅 30-Tage-Übersicht**: Tägliche Langzeittrends inklusive durchschnittlicher und 99%-Perzentil-Ping-Latenz für SLA-Monitoring
 
 ### 🎯 Professionelle Verfügbarkeitsstufen
 
@@ -179,10 +179,10 @@ CREATE TABLE status (
 
 ### 🛰️ Monitoring-Algorithmus
 
-1. **HTTP-Test**: GET-Request an konfigurierte URL
-2. **Ping-Messung**: ICMP-Ping zur Ermittlung der Latenz
+1. **Ping-Messung**: ICMP-Ping zur Ermittlung der Latenz
+2. **HTTP-Test**: GET-Request an die konfigurierte URL
 3. **Timeout-Handling**: 5 Sekunden maximale Wartezeit
-4. **Bewertung**: HTTP 2xx = Online | Timeout/Error oder fehlender Ping = Offline
+4. **Bewertung**: HTTP 2xx = Online, sonst Offline
 5. **Speicherung**: Timestamp + Status + Ping in SQLite
 6. **Retention**: Automatisches Cleanup alter Daten
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ cd internet-check
 
 - **Echtzeit-Updates**: Automatische Diagramm-Aktualisierung alle 60 Sekunden
 - **Responsive Design**: Optimiert für Desktop, Tablet und Mobile
+- **Umschaltbare Diagramme**: Verfügbarkeit und Ping lassen sich getrennt anzeigen
 - **Persistente Speicherung**: SQLite-Datenbank mit automatischem Cleanup
 - **Container-Ready**: Podman/Docker-basiert ohne komplexe Abhängigkeiten
 - **Hochperformant**: Minimaler Ressourcenverbrauch durch Alpine Linux

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,12 +10,13 @@
   .legend{background:#f5f5f5;padding:1rem;border-radius:8px;margin-bottom:2rem}
   .legend-item{display:inline-block;margin-right:2rem;margin-bottom:0.5rem}
   .legend-color{display:inline-block;width:20px;height:15px;margin-right:8px;vertical-align:middle;border-radius:3px}
+  .toggle-btn{margin-bottom:0.5rem}
 </style></head>
 
 <body>
   <h1>Internet Connection Monitor</h1>
   <p id=status>Starting…</p>
-  
+
   <div class="legend">
     <strong>Availability Levels:</strong><br>
     <div class="legend-item"><span class="legend-color" style="background:#4ade80"></span>Excellent (≥99.9%)</div>
@@ -23,24 +24,54 @@
     <div class="legend-item"><span class="legend-color" style="background:#ef4444"></span>Problematic (<98%)</div>
     <div class="legend-item"><span class="legend-color" style="background:#3b82f6"></span>No Data</div>
   </div>
-  
+
   <div class="chart-container">
     <div class="chart-title">Detailed Timeline</div>
-    <canvas id=c height=80></canvas>
+    <button id=toggleDetailed class=toggle-btn>Show Ping</button>
+    <canvas id=detailAvailability height=80></canvas>
+    <canvas id=detailPing height=80 style="display:none"></canvas>
   </div>
-  
+
   <div class="chart-container">
     <div class="chart-title">24-Hour Overview (last 24h)</div>
-    <canvas id=hourlyChart height=60></canvas>
+    <button id=toggleHourly class=toggle-btn>Show Ping</button>
+    <canvas id=hourlyAvailability height=60></canvas>
+    <canvas id=hourlyPing height=60 style="display:none"></canvas>
   </div>
-  
+
   <div class="chart-container">
     <div class="chart-title">Daily Overview (last 30 days)</div>
-    <canvas id=dailyChart height=60></canvas>
+    <button id=toggleDaily class=toggle-btn>Show Ping</button>
+    <canvas id=dailyAvailability height=60></canvas>
+    <canvas id=dailyPing height=60 style="display:none"></canvas>
   </div>
 
 <script>
-let chart=null, hourlyChart=null, dailyChart=null;
+let detailAvailChart=null, detailPingChart=null;
+let hourlyAvailChart=null, hourlyPingChart=null;
+let dailyAvailChart=null, dailyPingChart=null;
+
+function setupToggle(btnId, availId, pingId){
+  const btn=document.getElementById(btnId);
+  const availCanvas=document.getElementById(availId);
+  const pingCanvas=document.getElementById(pingId);
+  btn.addEventListener('click',()=>{
+    const showingPing=pingCanvas.style.display!=='none';
+    if(showingPing){
+      pingCanvas.style.display='none';
+      availCanvas.style.display='block';
+      btn.textContent='Show Ping';
+    }else{
+      pingCanvas.style.display='block';
+      availCanvas.style.display='none';
+      btn.textContent='Show Availability';
+    }
+  });
+}
+
+setupToggle('toggleDetailed','detailAvailability','detailPing');
+setupToggle('toggleHourly','hourlyAvailability','hourlyPing');
+setupToggle('toggleDaily','dailyAvailability','dailyPing');
 
 // Helper: convert UTC timestamp to local time
 function utcToLocal(utcTimestamp) {
@@ -76,171 +107,121 @@ async function reloadData(){
 
   // Detailed timeline - convert UTC timestamps to local times
   const localLabels = labels.map(utcTimestamp => utcToLocal(utcTimestamp).toISOString());
-  
-  if(!chart){
-    chart = new Chart(document.getElementById('c'),{
+
+  if(!detailAvailChart){
+    detailAvailChart = new Chart(document.getElementById('detailAvailability'),{
       type:'line',
       data:{labels:localLabels,
-            datasets:[
-              {label:'Online Status',data:values,stepped:true,fill:true,yAxisID:'y'},
-              {label:'Ping (ms)',data:pings,borderColor:'#3b82f6',yAxisID:'y1'}
-            ]},
-      options:{scales:{
-        y:{min:0,max:1,ticks:{stepSize:1,callback:v=>v?'Online':'Offline'}},
-        y1:{position:'right',beginAtZero:true},
-        x:{type:'time',time:{unit:'hour'}}
-      }}
+            datasets:[{label:'Online Status',data:values,stepped:true,fill:true,yAxisID:'y'}]},
+      options:{scales:{y:{min:0,max:1,ticks:{stepSize:1,callback:v=>v?'Online':'Offline'}},
+                       x:{type:'time',time:{unit:'hour'}}}}
     });
   }else{
-    chart.data.labels = localLabels;
-    chart.data.datasets[0].data = values;
-    chart.data.datasets[1].data = pings;
-    chart.update();
+    detailAvailChart.data.labels = localLabels;
+    detailAvailChart.data.datasets[0].data = values;
+    detailAvailChart.update();
   }
-  
-  // 24-hour chart - convert UTC to local time
+
+  if(!detailPingChart){
+    detailPingChart = new Chart(document.getElementById('detailPing'),{
+      type:'line',
+      data:{labels:localLabels,
+            datasets:[{label:'Ping (ms)',data:pings,borderColor:'#3b82f6'}]},
+      options:{scales:{y:{beginAtZero:true},x:{type:'time',time:{unit:'hour'}}}}
+    });
+  }else{
+    detailPingChart.data.labels = localLabels;
+    detailPingChart.data.datasets[0].data = pings;
+    detailPingChart.update();
+  }
+
+  // 24-hour charts
   if(hourly && hourly.length){
-    if(!hourlyChart){
-      hourlyChart = new Chart(document.getElementById('hourlyChart'),{
+    // Availability
+    if(!hourlyAvailChart){
+      hourlyAvailChart = new Chart(document.getElementById('hourlyAvailability'),{
         type:'bar',
         data:{
           labels:hourly.map(h=>h.uptime<0 ? formatHourLabel(h.hour)+' ?' : formatHourLabel(h.hour)),
-          datasets:[
-            {
-              label:'Hourly Status',
-              data:hourly.map(h=>h.uptime<0?0.5:h.uptime),
-              backgroundColor:hourly.map(h=>h.uptime<0?'#3b82f6':(h.uptime>=0.999?'#4ade80':(h.uptime>=0.98?'#eab308':'#ef4444'))),
-              borderWidth:0,
-              yAxisID:'y'
-            },
-            {
-              label:'Avg Ping (ms)',
-              data:hourly.map(h=>h.ping_avg),
-              type:'line',
-              borderColor:'#3b82f6',
-              backgroundColor:'transparent',
-              yAxisID:'y1',
-              tension:0.4
-            },
-            {
-              label:'99th % Ping (ms)',
-              data:hourly.map(h=>h.ping_p99),
-              type:'line',
-              borderColor:'#9333ea',
-              backgroundColor:'transparent',
-              borderDash:[5,5],
-              yAxisID:'y1',
-              tension:0.4
-            }
-          ]
+          datasets:[{
+            label:'Hourly Status',
+            data:hourly.map(h=>h.uptime<0?0.5:h.uptime),
+            backgroundColor:hourly.map(h=>h.uptime<0?'#3b82f6':(h.uptime>=0.999?'#4ade80':(h.uptime>=0.98?'#eab308':'#ef4444'))),
+            borderWidth:0
+          }]
         },
-        options:{
-          responsive:true,
-          scales:{
-            y:{min:0,max:1,ticks:{stepSize:0.2,callback:v=>(v*100).toFixed(0)+'%'}},
-            y1:{position:'right',beginAtZero:true,title:{display:true,text:'Ping (ms)'}},
-            x:{title:{display:true,text:'Hour (local time)'}}
-          },
-          plugins:{
-            tooltip:{
-              callbacks:{
-                label:ctx=>{
-                  const hourData = hourly[ctx.dataIndex];
-                  if(ctx.dataset.label==='Hourly Status'){
-                    return hourData.uptime<0 ? 'No data available' : `Availability: ${(ctx.parsed.y*100).toFixed(1)}%`;
-                  }
-                  if(ctx.dataset.label==='Avg Ping (ms)'){
-                    return hourData.ping_avg==null ? 'Avg ping: n/a' : `Avg ping: ${hourData.ping_avg.toFixed(1)} ms`;
-                  }
-                  if(ctx.dataset.label==='99th % Ping (ms)'){
-                    return hourData.ping_p99==null ? '99th % ping: n/a' : `99th % ping: ${hourData.ping_p99.toFixed(1)} ms`;
-                  }
-                }
-              }
-            }
-          }
-        }
+        options:{responsive:true,scales:{y:{min:0,max:1,ticks:{stepSize:0.2,callback:v=>(v*100).toFixed(0)+'%'}},
+                                         x:{title:{display:true,text:'Hour (local time)'}}}}
       });
     }else{
-      hourlyChart.data.labels = hourly.map(h=>h.uptime<0 ? formatHourLabel(h.hour)+' ?' : formatHourLabel(h.hour));
-      hourlyChart.data.datasets[0].data = hourly.map(h=>h.uptime<0?0.5:h.uptime);
-      hourlyChart.data.datasets[0].backgroundColor = hourly.map(h=>h.uptime<0?'#3b82f6':(h.uptime>=0.999?'#4ade80':(h.uptime>=0.98?'#eab308':'#ef4444')));
-      hourlyChart.data.datasets[1].data = hourly.map(h=>h.ping_avg);
-      hourlyChart.data.datasets[2].data = hourly.map(h=>h.ping_p99);
-      hourlyChart.update();
+      hourlyAvailChart.data.labels = hourly.map(h=>h.uptime<0 ? formatHourLabel(h.hour)+' ?' : formatHourLabel(h.hour));
+      hourlyAvailChart.data.datasets[0].data = hourly.map(h=>h.uptime<0?0.5:h.uptime);
+      hourlyAvailChart.data.datasets[0].backgroundColor = hourly.map(h=>h.uptime<0?'#3b82f6':(h.uptime>=0.999?'#4ade80':(h.uptime>=0.98?'#eab308':'#ef4444')));
+      hourlyAvailChart.update();
+    }
+
+    // Ping
+    if(!hourlyPingChart){
+      hourlyPingChart = new Chart(document.getElementById('hourlyPing'),{
+        type:'line',
+        data:{
+          labels:hourly.map(h=>formatHourLabel(h.hour)),
+          datasets:[
+            {label:'Avg Ping (ms)',data:hourly.map(h=>h.ping_avg),borderColor:'#3b82f6',tension:0.4},
+            {label:'99th % Ping (ms)',data:hourly.map(h=>h.ping_p99),borderColor:'#9333ea',borderDash:[5,5],tension:0.4}
+          ]},
+        options:{responsive:true,scales:{y:{beginAtZero:true},x:{title:{display:true,text:'Hour (local time)'}}}}
+      });
+    }else{
+      hourlyPingChart.data.labels = hourly.map(h=>formatHourLabel(h.hour));
+      hourlyPingChart.data.datasets[0].data = hourly.map(h=>h.ping_avg);
+      hourlyPingChart.data.datasets[1].data = hourly.map(h=>h.ping_p99);
+      hourlyPingChart.update();
     }
   }
-  
-  // Daily chart - convert UTC to local time
+
+  // Daily charts
   if(daily && daily.length){
-    if(!dailyChart){
-      dailyChart = new Chart(document.getElementById('dailyChart'),{
+    // Availability
+    if(!dailyAvailChart){
+      dailyAvailChart = new Chart(document.getElementById('dailyAvailability'),{
         type:'bar',
         data:{
           labels:daily.map(d=>d.uptime<0 ? formatDayLabel(d.date)+' ?' : formatDayLabel(d.date)),
-          datasets:[
-            {
-              label:'Daily Status',
-              data:daily.map(d=>d.uptime<0?0.5:d.uptime),
-              backgroundColor:daily.map(d=>d.uptime<0?'#3b82f6':(d.uptime>=0.999?'#4ade80':(d.uptime>=0.98?'#eab308':'#ef4444'))),
-              borderWidth:0,
-              yAxisID:'y'
-            },
-            {
-              label:'Avg Ping (ms)',
-              data:daily.map(d=>d.ping_avg),
-              type:'line',
-              borderColor:'#3b82f6',
-              backgroundColor:'transparent',
-              yAxisID:'y1',
-              tension:0.4
-            },
-            {
-              label:'99th % Ping (ms)',
-              data:daily.map(d=>d.ping_p99),
-              type:'line',
-              borderColor:'#9333ea',
-              backgroundColor:'transparent',
-              borderDash:[5,5],
-              yAxisID:'y1',
-              tension:0.4
-            }
-          ]
+          datasets:[{
+            label:'Daily Status',
+            data:daily.map(d=>d.uptime<0?0.5:d.uptime),
+            backgroundColor:daily.map(d=>d.uptime<0?'#3b82f6':(d.uptime>=0.999?'#4ade80':(d.uptime>=0.98?'#eab308':'#ef4444'))),
+            borderWidth:0
+          }]
         },
-        options:{
-          responsive:true,
-          scales:{
-            y:{min:0,max:1,ticks:{stepSize:0.2,callback:v=>(v*100).toFixed(0)+'%'}},
-            y1:{position:'right',beginAtZero:true,title:{display:true,text:'Ping (ms)'}},
-            x:{title:{display:true,text:'Day (local time)'}}
-          },
-          plugins:{
-            tooltip:{
-              callbacks:{
-                label:ctx=>{
-                  const dayData = daily[ctx.dataIndex];
-                  if(ctx.dataset.label==='Daily Status'){
-                    return dayData.uptime<0 ? 'No data available' : `Availability: ${(ctx.parsed.y*100).toFixed(1)}%`;
-                  }
-                  if(ctx.dataset.label==='Avg Ping (ms)'){
-                    return dayData.ping_avg==null ? 'Avg ping: n/a' : `Avg ping: ${dayData.ping_avg.toFixed(1)} ms`;
-                  }
-                  if(ctx.dataset.label==='99th % Ping (ms)'){
-                    return dayData.ping_p99==null ? '99th % ping: n/a' : `99th % ping: ${dayData.ping_p99.toFixed(1)} ms`;
-                  }
-                }
-              }
-            }
-          }
-        }
+        options:{responsive:true,scales:{y:{min:0,max:1,ticks:{stepSize:0.2,callback:v=>(v*100).toFixed(0)+'%'}},
+                                         x:{title:{display:true,text:'Day (local time)'}}}}
       });
     }else{
-      dailyChart.data.labels = daily.map(d=>d.uptime<0 ? formatDayLabel(d.date)+' ?' : formatDayLabel(d.date));
-      dailyChart.data.datasets[0].data = daily.map(d=>d.uptime<0?0.5:d.uptime);
-      dailyChart.data.datasets[0].backgroundColor = daily.map(d=>d.uptime<0?'#3b82f6':(d.uptime>=0.999?'#4ade80':(d.uptime>=0.98?'#eab308':'#ef4444')));
-      dailyChart.data.datasets[1].data = daily.map(d=>d.ping_avg);
-      dailyChart.data.datasets[2].data = daily.map(d=>d.ping_p99);
-      dailyChart.update();
+      dailyAvailChart.data.labels = daily.map(d=>d.uptime<0 ? formatDayLabel(d.date)+' ?' : formatDayLabel(d.date));
+      dailyAvailChart.data.datasets[0].data = daily.map(d=>d.uptime<0?0.5:d.uptime);
+      dailyAvailChart.data.datasets[0].backgroundColor = daily.map(d=>d.uptime<0?'#3b82f6':(d.uptime>=0.999?'#4ade80':(d.uptime>=0.98?'#eab308':'#ef4444')));
+      dailyAvailChart.update();
+    }
+
+    // Ping
+    if(!dailyPingChart){
+      dailyPingChart = new Chart(document.getElementById('dailyPing'),{
+        type:'line',
+        data:{
+          labels:daily.map(d=>formatDayLabel(d.date)),
+          datasets:[
+            {label:'Avg Ping (ms)',data:daily.map(d=>d.ping_avg),borderColor:'#3b82f6',tension:0.4},
+            {label:'99th % Ping (ms)',data:daily.map(d=>d.ping_p99),borderColor:'#9333ea',borderDash:[5,5],tension:0.4}
+          ]},
+        options:{responsive:true,scales:{y:{beginAtZero:true},x:{title:{display:true,text:'Day (local time)'}}}}
+      });
+    }else{
+      dailyPingChart.data.labels = daily.map(d=>formatDayLabel(d.date));
+      dailyPingChart.data.datasets[0].data = daily.map(d=>d.ping_avg);
+      dailyPingChart.data.datasets[1].data = daily.map(d=>d.ping_p99);
+      dailyPingChart.update();
     }
   }
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -65,11 +65,12 @@ function formatDayLabel(utcTimestamp) {
 
 async function reloadData(){
   const r = await fetch('/data');
-  const {labels,values,hourly,daily} = await r.json();
+  const {labels,values,pings,hourly,daily} = await r.json();
 
   // Set status text
+  const lastPing = pings.length ? pings.at(-1) : null;
   const statusTxt = values.length
-        ? (values.at(-1) ? '🟢 Connection up' : '🔴 No connection')
+        ? (values.at(-1) ? `🟢 Connection up${lastPing!==null?` (ping ${lastPing} ms)`:''}` : '🔴 No connection')
         : 'No data yet';
   document.getElementById('status').textContent = statusTxt;
 
@@ -80,15 +81,20 @@ async function reloadData(){
     chart = new Chart(document.getElementById('c'),{
       type:'line',
       data:{labels:localLabels,
-            datasets:[{label:'Online Status',data:values,stepped:true,fill:true}]},
+            datasets:[
+              {label:'Online Status',data:values,stepped:true,fill:true,yAxisID:'y'},
+              {label:'Ping (ms)',data:pings,borderColor:'#3b82f6',yAxisID:'y1'}
+            ]},
       options:{scales:{
         y:{min:0,max:1,ticks:{stepSize:1,callback:v=>v?'Online':'Offline'}},
+        y1:{position:'right',beginAtZero:true},
         x:{type:'time',time:{unit:'hour'}}
       }}
     });
   }else{
     chart.data.labels = localLabels;
     chart.data.datasets[0].data = values;
+    chart.data.datasets[1].data = pings;
     chart.update();
   }
   

--- a/templates/index.html
+++ b/templates/index.html
@@ -105,17 +105,40 @@ async function reloadData(){
         type:'bar',
         data:{
           labels:hourly.map(h=>h.uptime<0 ? formatHourLabel(h.hour)+' ?' : formatHourLabel(h.hour)),
-          datasets:[{
-            label:'Hourly Status',
-            data:hourly.map(h=>h.uptime<0?0.5:h.uptime),
-            backgroundColor:hourly.map(h=>h.uptime<0?'#3b82f6':(h.uptime>=0.999?'#4ade80':(h.uptime>=0.98?'#eab308':'#ef4444'))),
-            borderWidth:0
-          }]
+          datasets:[
+            {
+              label:'Hourly Status',
+              data:hourly.map(h=>h.uptime<0?0.5:h.uptime),
+              backgroundColor:hourly.map(h=>h.uptime<0?'#3b82f6':(h.uptime>=0.999?'#4ade80':(h.uptime>=0.98?'#eab308':'#ef4444'))),
+              borderWidth:0,
+              yAxisID:'y'
+            },
+            {
+              label:'Avg Ping (ms)',
+              data:hourly.map(h=>h.ping_avg),
+              type:'line',
+              borderColor:'#3b82f6',
+              backgroundColor:'transparent',
+              yAxisID:'y1',
+              tension:0.4
+            },
+            {
+              label:'99th % Ping (ms)',
+              data:hourly.map(h=>h.ping_p99),
+              type:'line',
+              borderColor:'#9333ea',
+              backgroundColor:'transparent',
+              borderDash:[5,5],
+              yAxisID:'y1',
+              tension:0.4
+            }
+          ]
         },
         options:{
           responsive:true,
           scales:{
             y:{min:0,max:1,ticks:{stepSize:0.2,callback:v=>(v*100).toFixed(0)+'%'}},
+            y1:{position:'right',beginAtZero:true,title:{display:true,text:'Ping (ms)'}},
             x:{title:{display:true,text:'Hour (local time)'}}
           },
           plugins:{
@@ -123,7 +146,15 @@ async function reloadData(){
               callbacks:{
                 label:ctx=>{
                   const hourData = hourly[ctx.dataIndex];
-                  return hourData.uptime<0 ? 'No data available' : `Availability: ${(ctx.parsed.y*100).toFixed(1)}%`;
+                  if(ctx.dataset.label==='Hourly Status'){
+                    return hourData.uptime<0 ? 'No data available' : `Availability: ${(ctx.parsed.y*100).toFixed(1)}%`;
+                  }
+                  if(ctx.dataset.label==='Avg Ping (ms)'){
+                    return hourData.ping_avg==null ? 'Avg ping: n/a' : `Avg ping: ${hourData.ping_avg.toFixed(1)} ms`;
+                  }
+                  if(ctx.dataset.label==='99th % Ping (ms)'){
+                    return hourData.ping_p99==null ? '99th % ping: n/a' : `99th % ping: ${hourData.ping_p99.toFixed(1)} ms`;
+                  }
                 }
               }
             }
@@ -134,6 +165,8 @@ async function reloadData(){
       hourlyChart.data.labels = hourly.map(h=>h.uptime<0 ? formatHourLabel(h.hour)+' ?' : formatHourLabel(h.hour));
       hourlyChart.data.datasets[0].data = hourly.map(h=>h.uptime<0?0.5:h.uptime);
       hourlyChart.data.datasets[0].backgroundColor = hourly.map(h=>h.uptime<0?'#3b82f6':(h.uptime>=0.999?'#4ade80':(h.uptime>=0.98?'#eab308':'#ef4444')));
+      hourlyChart.data.datasets[1].data = hourly.map(h=>h.ping_avg);
+      hourlyChart.data.datasets[2].data = hourly.map(h=>h.ping_p99);
       hourlyChart.update();
     }
   }
@@ -145,17 +178,40 @@ async function reloadData(){
         type:'bar',
         data:{
           labels:daily.map(d=>d.uptime<0 ? formatDayLabel(d.date)+' ?' : formatDayLabel(d.date)),
-          datasets:[{
-            label:'Daily Status',
-            data:daily.map(d=>d.uptime<0?0.5:d.uptime),
-            backgroundColor:daily.map(d=>d.uptime<0?'#3b82f6':(d.uptime>=0.999?'#4ade80':(d.uptime>=0.98?'#eab308':'#ef4444'))),
-            borderWidth:0
-          }]
+          datasets:[
+            {
+              label:'Daily Status',
+              data:daily.map(d=>d.uptime<0?0.5:d.uptime),
+              backgroundColor:daily.map(d=>d.uptime<0?'#3b82f6':(d.uptime>=0.999?'#4ade80':(d.uptime>=0.98?'#eab308':'#ef4444'))),
+              borderWidth:0,
+              yAxisID:'y'
+            },
+            {
+              label:'Avg Ping (ms)',
+              data:daily.map(d=>d.ping_avg),
+              type:'line',
+              borderColor:'#3b82f6',
+              backgroundColor:'transparent',
+              yAxisID:'y1',
+              tension:0.4
+            },
+            {
+              label:'99th % Ping (ms)',
+              data:daily.map(d=>d.ping_p99),
+              type:'line',
+              borderColor:'#9333ea',
+              backgroundColor:'transparent',
+              borderDash:[5,5],
+              yAxisID:'y1',
+              tension:0.4
+            }
+          ]
         },
         options:{
           responsive:true,
           scales:{
             y:{min:0,max:1,ticks:{stepSize:0.2,callback:v=>(v*100).toFixed(0)+'%'}},
+            y1:{position:'right',beginAtZero:true,title:{display:true,text:'Ping (ms)'}},
             x:{title:{display:true,text:'Day (local time)'}}
           },
           plugins:{
@@ -163,7 +219,15 @@ async function reloadData(){
               callbacks:{
                 label:ctx=>{
                   const dayData = daily[ctx.dataIndex];
-                  return dayData.uptime<0 ? 'No data available' : `Availability: ${(ctx.parsed.y*100).toFixed(1)}%`;
+                  if(ctx.dataset.label==='Daily Status'){
+                    return dayData.uptime<0 ? 'No data available' : `Availability: ${(ctx.parsed.y*100).toFixed(1)}%`;
+                  }
+                  if(ctx.dataset.label==='Avg Ping (ms)'){
+                    return dayData.ping_avg==null ? 'Avg ping: n/a' : `Avg ping: ${dayData.ping_avg.toFixed(1)} ms`;
+                  }
+                  if(ctx.dataset.label==='99th % Ping (ms)'){
+                    return dayData.ping_p99==null ? '99th % ping: n/a' : `99th % ping: ${dayData.ping_p99.toFixed(1)} ms`;
+                  }
                 }
               }
             }
@@ -174,6 +238,8 @@ async function reloadData(){
       dailyChart.data.labels = daily.map(d=>d.uptime<0 ? formatDayLabel(d.date)+' ?' : formatDayLabel(d.date));
       dailyChart.data.datasets[0].data = daily.map(d=>d.uptime<0?0.5:d.uptime);
       dailyChart.data.datasets[0].backgroundColor = daily.map(d=>d.uptime<0?'#3b82f6':(d.uptime>=0.999?'#4ade80':(d.uptime>=0.98?'#eab308':'#ef4444')));
+      dailyChart.data.datasets[1].data = daily.map(d=>d.ping_avg);
+      dailyChart.data.datasets[2].data = daily.map(d=>d.ping_p99);
       dailyChart.update();
     }
   }


### PR DESCRIPTION
## Summary
- measure ping latency alongside HTTP checks and store it in the database
- expose ping data via `/data` endpoint and show latest ping in dashboard

## Testing
- `python -m py_compile monitor.py`


------
https://chatgpt.com/codex/tasks/task_e_689cf7050510832098b5eb58fdb8c112